### PR TITLE
remove redundant question from Process bubble

### DIFF
--- a/content/qa/skills/process_and_soft_skills.md
+++ b/content/qa/skills/process_and_soft_skills.md
@@ -34,7 +34,6 @@ title = "Process and soft skills"
 
 - What are some good practices in keeping good relations with developers?
 - What specifies a valuable feedback?
-- Why are the benefits of knowing whole application/domain?
 - What phases of a sprint can a QA participate in and how?
 - What are pros of managing a project in Agile?
 


### PR DESCRIPTION
Question about implementation details is contained in another bubble "Testing analysis" so I removed it from "Process and soft skills"